### PR TITLE
Add tooltip on hover of replaced words

### DIFF
--- a/content.js
+++ b/content.js
@@ -103,6 +103,8 @@
           }
           return replacement;
         });
+
+        createTooltip(el);
       }
     } else {
       for (let child of el.childNodes) {
@@ -210,4 +212,33 @@
       characterDataOldValue: false,
     });
   });
+
+  const createTooltip = (el) => {
+    const newElement = document.createElement("div");
+
+    newElement.innerText = "Tooltip text";
+    newElement.style.position = "absolute";
+    newElement.style.backgroundColor = "black";
+    newElement.style.color = "white";
+    newElement.style.padding = "5px";
+    newElement.style.borderRadius = "5px";
+    newElement.style.fontSize = "12px";
+    newElement.style.visibility = "hidden";
+    newElement.style.zIndex = "1000";
+
+    document.body.appendChild(newElement);
+
+    const parentNode =  el.parentNode;
+
+    parentNode.addEventListener("mouseenter", function () {
+      const rect = parentNode.getBoundingClientRect(); // Get the element's position
+      newElement.style.left = `${rect.left + window.scrollX}px`;
+      newElement.style.top = `${rect.top + window.scrollY - newElement.offsetHeight}px`; 
+      newElement.style.visibility = "visible";
+    });
+
+    parentNode.addEventListener("mouseleave", function () {
+      newElement.style.visibility = "hidden";
+    });
+  }
 })();


### PR DESCRIPTION
Once a word is replaced, a tooltip is made

<img width="218" alt="Screenshot 2024-10-07 224825" src="https://github.com/user-attachments/assets/6fa8e1eb-14b0-44ed-960f-724b54b168f7">

As for the actual text, should this be stored in the API?

Also, it seems for anchor links the tooltip isn't place horizontally above the replaced word:

![image](https://github.com/user-attachments/assets/2ee37ffc-55af-4a2e-908a-6a26c1ca2c3c)
