### PR TITLE
Ensure tooltip text don't get replaced

### DIFF
--- a/content.js
+++ b/content.js
@@ -122,11 +122,11 @@
   const anyChildOfBody = "/html/body//";
   // const doesNotContainAncestorWithRoleTextbox =
   //   "div[not(ancestor-or-self::*[@role=textbox])]/";
-  const isTextButNotPartOfJsScript = "text()[not(parent::script)]";
+  const isTextButNotPartOfJsScriptOrTooltip = "text()[not(parent::script) and not(ancestor::*[contains(@class, 'tooltip')])]";
   const xpathExpression =
     anyChildOfBody +
     //  + doesNotContainAncestorWithRoleTextbox;
-    isTextButNotPartOfJsScript;
+    isTextButNotPartOfJsScriptOrTooltip;
 
   const replaceTextInNodes = () => {
     if (regex == null || typeof regex === "undefined") {
@@ -238,6 +238,7 @@
         : text;
 
     newElement.innerText = toolTipText;
+    newElement.classList.add("tooltip");
     newElement.style.position = "absolute";
     newElement.style.backgroundColor = "black";
     newElement.style.color = "white";


### PR DESCRIPTION
- Add a class to the tooltips
- Add a rule to the XPath to ensure the tooltip text doesn't get replaced (resulting in an infinite loop and performance issues)